### PR TITLE
Improve the script (see each commit)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ This script automates the installation and configuration of ZFSBootMenu on a Lin
    apt upgrade
    apt install curl
    curl -O https://raw.githubusercontent.com/NLaundry/zfsbootmenu-autoinstaller/main/setup-zfsbootmenu.sh
-   chmod +x
+   chmod +x setup-zfsbootmenu.sh
    ./setup-zfsbootmenu.sh
    ```
 

--- a/setup-zfsbootmenu.sh
+++ b/setup-zfsbootmenu.sh
@@ -157,7 +157,7 @@ enter_chroot() {
 	
 	# Install system utilities
 	echo "Installing system utilities..."
-	apt install -y systemd-timesyncd net-tools iproute2 isc-dhcp-client iputils-ping traceroute curl wget dnsutils ethtool ifupdown tcpdump nmap nano vim htop openssh-server git tmux
+	apt install -y network-manager systemd-timesyncd net-tools iproute2 isc-dhcp-client iputils-ping traceroute curl wget dnsutils ethtool ifupdown tcpdump nmap nano vim htop openssh-server git tmux
 	
 	# Perform system upgrade
 	echo "Running dist-upgrade to upgrade all packages to the latest version..."

--- a/setup-zfsbootmenu.sh
+++ b/setup-zfsbootmenu.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 # Automatically set other variables
-BOOT_DISK="/dev/nvme0n1"
 BOOT_PART="1"
-POOL_DISK="/dev/nvme0n1"
 POOL_PART="2"
 POOL_NAME="zroot"
 MOUNT_POINT="/mnt"

--- a/setup-zfsbootmenu.sh
+++ b/setup-zfsbootmenu.sh
@@ -92,7 +92,7 @@ partition_disk() {
 
 create_zpool() {
   echo "Creating ZFS pool and datasets..."
-  zpool create -f -o ashift=12 -O compression=lz4 -O acltype=posixacl -O xattr=sa -O relatime=on -o autotrim=on -o compatibility=openzfs-2.1-linux -m none $POOL_NAME ${POOL_DISK}${POOL_PART}
+  zpool create -f -o ashift=12 -o acltype=posixacl -o xattr=sa -m none $POOL_NAME ${POOL_DISK}${POOL_PART}
   zfs create -o mountpoint=none $POOL_NAME/ROOT
   zfs create -o mountpoint=/ -o canmount=noauto $POOL_NAME/ROOT/$ID
   zfs create -o mountpoint=/home $POOL_NAME/home

--- a/setup-zfsbootmenu.sh
+++ b/setup-zfsbootmenu.sh
@@ -92,7 +92,7 @@ partition_disk() {
 
 create_zpool() {
   echo "Creating ZFS pool and datasets..."
-  zpool create -f -o ashift=12 -O compression=lz4 -O acltype=posixacl -O xattr=sa -O relatime=on -o autotrim=on -o compatibility=openzfs-2.1-linux -m none $POOL_NAME ${POOL_DISK}p${POOL_PART}
+  zpool create -f -o ashift=12 -O compression=lz4 -O acltype=posixacl -O xattr=sa -O relatime=on -o autotrim=on -o compatibility=openzfs-2.1-linux -m none $POOL_NAME ${POOL_DISK}${POOL_PART}
   zfs create -o mountpoint=none $POOL_NAME/ROOT
   zfs create -o mountpoint=/ -o canmount=noauto $POOL_NAME/ROOT/$ID
   zfs create -o mountpoint=/home $POOL_NAME/home
@@ -195,12 +195,12 @@ enter_chroot() {
 	
 	# Set up EFI filesystem
 	echo "Setting up EFI filesystem..."
-	mkfs.vfat -F32 ${BOOT_DISK}p${BOOT_PART}
+	mkfs.vfat -F32 ${BOOT_DISK}${BOOT_PART}
 	
 	# Configure fstab entry for EFI
 	echo "Configuring fstab for EFI partition..."
 		cat <<-EOF_FSTAB >> /etc/fstab
-		$(blkid | grep "${BOOT_DISK}p${BOOT_PART}" | cut -d ' ' -f 2) /boot/efi vfat defaults 0 0
+		$(blkid | grep "${BOOT_DISK}${BOOT_PART}" | cut -d ' ' -f 2) /boot/efi vfat defaults 0 0
 		EOF_FSTAB
 	
 	# Mount EFI partition

--- a/setup-zfsbootmenu.sh
+++ b/setup-zfsbootmenu.sh
@@ -6,7 +6,6 @@ BOOT_PART="1"
 POOL_DISK="/dev/nvme0n1"
 POOL_PART="2"
 POOL_NAME="zroot"
-KERNEL_VERSION=$(uname -r)  # Automatically get current kernel version
 MOUNT_POINT="/mnt"
 ID=$(source /etc/os-release && echo "$ID")  # Get OS ID from /etc/os-release
 
@@ -147,7 +146,7 @@ enter_chroot() {
 	# Update and install necessary packages
 	export DEBIAN_FRONTEND=noninteractive
 	apt update
-	apt install -y locales linux-headers-$KERNEL_VERSION linux-image-amd64 dkms
+	apt install -y locales linux-headers-generic linux-image-amd64 dkms
 	
 	apt install -y zfsutils-linux
 	

--- a/setup-zfsbootmenu.sh
+++ b/setup-zfsbootmenu.sh
@@ -6,6 +6,7 @@ POOL_PART="2"
 POOL_NAME="zroot"
 MOUNT_POINT="/mnt"
 ID=$(source /etc/os-release && echo "$ID")  # Get OS ID from /etc/os-release
+VERSION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d'=' -f2) # get codename
 
 get_username_and_password(){
   # Prompt user for variables
@@ -57,17 +58,17 @@ generate_hostid() {
 configure_apt_sources() {
   echo "Configuring APT sources..."
   cat > /etc/apt/sources.list <<EOF
-deb http://deb.debian.org/debian bookworm main contrib non-free-firmware
-deb-src http://deb.debian.org/debian bookworm main contrib non-free-firmware
+deb http://deb.debian.org/debian $VERSION_CODENAME main contrib non-free-firmware
+deb-src http://deb.debian.org/debian $VERSION_CODENAME main contrib non-free-firmware
 
-deb http://deb.debian.org/debian-security bookworm-security main contrib non-free-firmware
-deb-src http://deb.debian.org/debian-security/ bookworm-security main contrib non-free-firmware
+deb http://deb.debian.org/debian-security $VERSION_CODENAME-security main contrib non-free-firmware
+deb-src http://deb.debian.org/debian-security/ $VERSION_CODENAME-security main contrib non-free-firmware
 
-deb http://deb.debian.org/debian bookworm-updates main contrib non-free-firmware
-deb-src http://deb.debian.org/debian bookworm-updates main contrib non-free-firmware
+deb http://deb.debian.org/debian $VERSION_CODENAME-updates main contrib non-free-firmware
+deb-src http://deb.debian.org/debian $VERSION_CODENAME-updates main contrib non-free-firmware
 
-deb http://deb.debian.org/debian bookworm-backports main contrib non-free-firmware
-deb-src http://deb.debian.org/debian bookworm-backports main contrib non-free-firmware
+deb http://deb.debian.org/debian $VERSION_CODENAME-backports main contrib non-free-firmware
+deb-src http://deb.debian.org/debian $VERSION_CODENAME-backports main contrib non-free-firmware
 EOF
 }
 
@@ -108,7 +109,7 @@ export_import_zpool() {
 
 setup_base_system() {
   echo "Installing base system with debootstrap..."
-  debootstrap bookworm $MOUNT_POINT
+  debootstrap $VERSION_CODENAME $MOUNT_POINT
   cp /etc/hostid $MOUNT_POINT/etc/hostid
   cp /etc/resolv.conf $MOUNT_POINT/etc/resolv.conf
 }
@@ -130,17 +131,17 @@ enter_chroot() {
 	
 	# Configure apt sources
 		cat > /etc/apt/sources.list <<-EOF_APT
-		deb http://deb.debian.org/debian bookworm main contrib non-free-firmware
-		deb-src http://deb.debian.org/debian bookworm main contrib non-free-firmware
+		deb http://deb.debian.org/debian $VERSION_CODENAME main contrib non-free-firmware
+		deb-src http://deb.debian.org/debian $VERSION_CODENAME main contrib non-free-firmware
 		
-		deb http://deb.debian.org/debian-security bookworm-security main contrib non-free-firmware
-		deb-src http://deb.debian.org/debian-security/ bookworm-security main contrib non-free-firmware
+		deb http://deb.debian.org/debian-security $VERSION_CODENAME-security main contrib non-free-firmware
+		deb-src http://deb.debian.org/debian-security/ $VERSION_CODENAME-security main contrib non-free-firmware
 		
-		deb http://deb.debian.org/debian bookworm-updates main contrib non-free-firmware
-		deb-src http://deb.debian.org/debian bookworm-updates main contrib non-free-firmware
+		deb http://deb.debian.org/debian $VERSION_CODENAME-updates main contrib non-free-firmware
+		deb-src http://deb.debian.org/debian $VERSION_CODENAME-updates main contrib non-free-firmware
 		
-		deb http://deb.debian.org/debian bookworm-backports main contrib non-free-firmware
-		deb-src http://deb.debian.org/debian bookworm-backports main contrib non-free-firmware
+		deb http://deb.debian.org/debian $VERSION_CODENAME-backports main contrib non-free-firmware
+		deb-src http://deb.debian.org/debian $VERSION_CODENAME-backports main contrib non-free-firmware
 		EOF_APT
 	
 	# Update and install necessary packages

--- a/setup-zfsbootmenu.sh
+++ b/setup-zfsbootmenu.sh
@@ -75,7 +75,9 @@ EOF
 
 install_host_packages() {
   echo "Installing necessary packages"
+  export DEBIAN_FRONTEND=noninteractive
   apt update
+  apt install -y linux-headers-generic
   apt install -y dosfstools efibootmgr curl debootstrap gdisk dkms zfsutils-linux # Install efibootmgr 
   # Setup efivards kernel module
   echo "Setup efivars kernel module"

--- a/setup-zfsbootmenu.sh
+++ b/setup-zfsbootmenu.sh
@@ -52,7 +52,7 @@ select_disk() {
 # Functions
 generate_hostid() {
   echo "Generating host ID..."
-  zgenhostid -f 0x00bab10c
+  zgenhostid -f
 }
 
 configure_apt_sources() {
@@ -256,9 +256,9 @@ final_cleanup() {
 echo "Starting ZFS Boot Menu installation..."
 select_disk
 get_username_and_password
-generate_hostid
 configure_apt_sources
 install_host_packages
+generate_hostid
 partition_disk
 create_zpool
 export_import_zpool


### PR DESCRIPTION
Thank for the script, I have some commits to improve it.

There are two areas I wish to improve on but I'm out of juice right now:

1. try not to use /dev/sda instead use /dev/disk/by-id/<disk_id> (or /dev/disk/by-id/diska-part2), but in kvm environment, disk do not have it own id, so this approach do not work, it should be mention on readme with a command line to export and reimport using disk `by-id` on physical disk to improve zfs reliability (eg: /dev/sda could be /dev/sdb the on the next machine reboot - using by-id will prevent this).
2. mordenize /etc/apt/source.list, in debian 13, a new format is being use (via package `modernize-sources`), it would be good if include this fix.

Please ping me if anything is unclear, thank you!

P/s: forgot to mention, I use kvm to test this script, when using kvm with UEFI, configure UEFI `without` secure boot to prevent being block `mobprobe zfs` - maybe this should go to readme as well :smiley: .